### PR TITLE
fixed deprecation warning for add_lexer call

### DIFF
--- a/sphinxcontrib/inmanta/dsl.py
+++ b/sphinxcontrib/inmanta/dsl.py
@@ -188,4 +188,4 @@ class InmantaDomain(Domain):
 
 def setup(app):
     app.add_domain(InmantaDomain)
-    app.add_lexer("inmanta", InmantaLexer())
+    app.add_lexer("inmanta", InmantaLexer)


### PR DESCRIPTION
# Description

Fixes `RemovedInSphinx40Warning: app.add_lexer() API changed; Please give lexer class instead of instance` ([docs](https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_lexer)).

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
