### PR TITLE
use stable inmanta-core api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.4.0 (?)
 Changes in this release:
  - Correctly create an instance of the Project class.
+ - Use stable inmanta-core api
 
 # 1.3.0 (20-06-30)
 

--- a/sphinxcontrib/inmanta/api.py
+++ b/sphinxcontrib/inmanta/api.py
@@ -357,7 +357,7 @@ modulepath: %s
         mod: module.Module
         try:
             mod = module.Module(None, module_path)
-        except module.InvalidMetadata:
+        except (module.InvalidModuleException, module.InvalidMetadata):
             return None, None
         else:
             return mod, mod.get_all_submodules()

--- a/sphinxcontrib/inmanta/api.py
+++ b/sphinxcontrib/inmanta/api.py
@@ -335,19 +335,17 @@ modulepath: %s
         return lines
 
     def emit_intro(self, module, source_repo):
-        lines = self.emit_heading("Module " + module._meta["name"], "=")
+        lines = self.emit_heading("Module " + module.name, "=")
 
-        if "description" in module._meta:
-            lines.append(module._meta["description"])
+        if module.metadata.description is not None:
+            lines.append(module.metadata.description)
             lines.append("")
 
-        lines.append(" * License: " + module._meta["license"])
-        lines.append(" * Version: " + str(module._meta["version"]))
-        if "author" in module._meta:
-            lines.append(" * Author: " + module._meta["author"])
+        lines.append(" * License: " + module.metadata.license)
+        lines.append(" * Version: " + str(module.metadata.version))
 
-        if "compiler_version" in module._meta:
-            lines.append(" * This module requires compiler version %s or higher" % module._meta["compiler_version"])
+        if module.metadata.compiler_version is not None:
+            lines.append(" * This module requires compiler version %s or higher" % module.metadata.compiler_version)
 
         if source_repo is not None:
             lines.append(" * Upstream project: " + source_repo)
@@ -356,10 +354,13 @@ modulepath: %s
         return lines
 
     def _get_modules(self, module_path):
-        if os.path.exists(module_path) and module.Module.is_valid_module(module_path):
+        mod: module.Module
+        try:
             mod = module.Module(None, module_path)
+        except module.InvalidMetadata:
+            return None, None
+        else:
             return mod, mod.get_all_submodules()
-        return None, None
 
     def run(self, module_repo, module, extra_modules, source_repo):
         module_path = os.path.join(module_repo, module)


### PR DESCRIPTION
# Description

Use stable inmanta-core api (requires inmanta/inmanta-core#2854). After merging this I plan to take the following steps:
- release 1.4.0
- bump inmanta-sphinx dependency for inmanta-dev-dependencies
- bump inmanta-dev-dependencies for the product repos
I believe this should resolve all current docs build failures.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
