### PR TITLE
added project install for compatibility with latest inmanta-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 - Fix compatibility with recommonmark
 - Fix compatibility with inmanta modules V2
+- Added explicit project install for compatibility with latest inmanta-core
 
 # v 1.4.0 (2021-04-15)
 Changes in this release:

--- a/sphinxcontrib/inmanta/api.py
+++ b/sphinxcontrib/inmanta/api.py
@@ -108,7 +108,12 @@ modulepath: %s
 
             os.chdir(project_dir)
             project = Project.get()
-            project.load()
+            try:
+                # This is required for Modules V2, which don't install on each compile
+                project.load(install=True)
+            except TypeError:
+                # install argument doesn't exist on older versions
+                project.load()
             _, root_ns = compiler.get_types_and_scopes()
 
             module_ns = root_ns.get_child(name)


### PR DESCRIPTION
I expect this should fix the docs build issues. I'm not sure how to test it except by patch releasing it and inmanta-dev-dependencies. Do I just do that then?