### PR TITLE
Issue/46 modules v2 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ charset = utf-8
 
 [*.py]
 max_line_length = 128
+
+[Jenkinsfile-*]
+indent_size = 2

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -30,7 +30,6 @@ pipeline {
         axes {
           axis {
             name "CORE_BRANCH"
-            // TODO: add note to major release docs to update this
             values "master", "iso4"
           }
           axis {

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -4,11 +4,6 @@ pipeline {
     disableConcurrentBuilds()
   }
 
-  parameters
-  {
-    string(name: 'CORE_BRANCH', defaultValue: 'master', description: 'branch in the inmanta repo')
-  }
-
   triggers {
     cron(BRANCH_NAME == "master" ? "H H(2-5) * * *": "")
   }
@@ -19,31 +14,97 @@ pipeline {
   }
 
   stages {
-    stage("setup"){
-      steps{
+    stage("Checkout source") {
+      steps {
         deleteDir()
         dir("inmanta-sphinx") {
           checkout scm
         }
-        script{
-          checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: params.CORE_BRANCH]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'inmanta-core']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/inmanta-core.git']]]
-          checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
-
-          sh 'rm -rf $INMANTA_TEST_ENV; python3 -m venv $INMANTA_TEST_ENV; $INMANTA_TEST_ENV/bin/python3 -m pip install --upgrade pip'
-          // Ensure the inmanta package is installed. This package is required to determine the version number of the documentation.
-          sh '$INMANTA_TEST_ENV/bin/python3 -m pip install --pre inmanta'
-          sh '$INMANTA_TEST_ENV/bin/python3 -m pip install -r ./inmanta-core/requirements.txt -r ./inmanta-core/requirements.dev.txt'
-          sh '$INMANTA_TEST_ENV/bin/python3 -m pip install ./inmanta-core'
-          sh '$INMANTA_TEST_ENV/bin/python3 -m pip install ./inmanta-sphinx'
-          sh 'rm -rf inmanta-core/docs/reference/modules; mkdir inmanta-core/docs/reference/modules'
-        }
       }
     }
-    stage("test"){
-      steps{
-        script{
-          sh '$INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module_repo $(pwd) --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst'
-          sh '$INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build'
+
+    stage("Matrix") {
+      matrix {
+        axes {
+          axis {
+            name "CORE_BRANCH"
+            // TODO: add note to major release docs to update this
+            values "master", "iso4"
+          }
+          axis {
+            name "MODULES_V2"
+            values "true", "false"
+          }
+        }
+        excludes {
+          exclude {
+            axis {
+              name "CORE_BRANCH"
+              values "iso4"
+            }
+            axis {
+              name "MODULES_V2"
+              values "true"
+            }
+          }
+        }
+        stages {
+          stage("check out inmanta-core") {
+            steps {
+              dir("inmanta-core") {
+                deleteDir()
+              }
+              checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: env.CORE_BRANCH]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'inmanta-core']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/inmanta-core.git']]]
+            }
+          }
+
+          stage("set up environment") {
+            steps {
+              sh '''
+                rm -rf $INMANTA_TEST_ENV
+                python3 -m venv $INMANTA_TEST_ENV
+                $INMANTA_TEST_ENV/bin/python3 -m pip install --upgrade pip
+                $INMANTA_TEST_ENV/bin/python3 -m pip install -r ./inmanta-core/requirements.txt -r ./inmanta-core/requirements.dev.txt
+                $INMANTA_TEST_ENV/bin/python3 -m pip install ./inmanta-core ./inmanta-sphinx
+                rm -rf inmanta-core/docs/reference/modules
+                mkdir inmanta-core/docs/reference/modules
+              '''
+            }
+          }
+
+          stage("test module v1") {
+            when {
+              environment name: "MODULES_V2", value: "false"
+            }
+            steps {
+              dir("std") {
+                deleteDir()
+              }
+              checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
+
+              sh '''
+                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module_repo $(pwd) --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst'
+                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build'
+              '''
+            }
+          }
+
+          stage("test module v2") {
+            when {
+              environment name: "MODULES_V2", value: "false"
+            }
+            steps {
+              dir("std") {
+                deleteDir()
+              }
+              sh "$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std"
+
+              sh '''
+                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst'
+                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build'
+              '''
+            }
+          }
         }
       }
     }

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -86,8 +86,8 @@ pipeline {
               checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
 
               sh '''
-                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module_repo $(pwd) --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst'
-                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build'
+                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module_repo $(pwd) --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst
+                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build
               '''
             }
           }

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -102,7 +102,7 @@ pipeline {
               dir("std") {
                 deleteDir()
               }
-              sh "$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std"
+              sh "$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std --pre"
 
               sh '''
                 $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst'

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -105,8 +105,8 @@ pipeline {
               sh '$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std --pre'
 
               sh '''
-                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst'
-                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build'
+                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst
+                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build
               '''
             }
           }

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -91,7 +91,7 @@ pipeline {
 
           stage("test module v2") {
             when {
-              environment name: "MODULES_V2", value: "false"
+              environment name: "MODULES_V2", value: "true"
             }
             steps {
               dir("std") {

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -51,7 +51,7 @@ pipeline {
           }
         }
         options {
-          lock("inmanta-sphinx-${BRANCH_NAME}-sequential-matrix")
+          lock("inmanta-sphinx-sequential-matrix/${BRANCH_NAME}")
         }
         stages {
           stage("check out inmanta-core") {

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -11,6 +11,8 @@ pipeline {
   environment {
     INMANTA_TEST_ENV="${env.WORKSPACE}/env"
     PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
+    // don't require product package (inmanta or inmanta-service-orchestrator)
+    INMANTA_DONT_DISCOVER_VERSION=1
   }
 
   stages {

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -102,7 +102,7 @@ pipeline {
               dir("std") {
                 deleteDir()
               }
-              sh "$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std --pre"
+              sh '$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std --pre'
 
               sh '''
                 $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module std --source-repo https://github.com/inmanta/ --file inmanta-core/docs/reference/modules/std.rst'

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -48,6 +48,9 @@ pipeline {
             }
           }
         }
+        options {
+          lock("inmanta-sphinx-${BRANCH_NAME}-sequential-matrix")
+        }
         stages {
           stage("check out inmanta-core") {
             steps {

--- a/sphinxcontrib/inmanta/api.py
+++ b/sphinxcontrib/inmanta/api.py
@@ -353,9 +353,9 @@ modulepath: %s
             lines.append("")
 
         lines.append(" * License: " + module.metadata.license)
-        lines.append(" * Version: " + str(module.metadata.version))
+        lines.append(" * Version: " + str(module.version))
 
-        if module.metadata.compiler_version is not None:
+        if hasattr(module.metadata, "compiler_version") and module.metadata.compiler_version is not None:
             lines.append(" * This module requires compiler version %s or higher" % module.metadata.compiler_version)
 
         if source_repo is not None:


### PR DESCRIPTION
# Description

- Added support for modules v2.
- Extended Jenkinsfile to run test against both master and iso4 with a v1 and a v2 module. The current approach did not result in what I was hoping for but I haven't had the time to clean it up. The [Jenkins output](https://jenkins.inmanta.com/job/docs/job/inmanta-sphinx/job/issue%252F46-modules-v2-support/) is not very readable. I'll leave it to the reviewers to decide if it suffices or not.

closes #46

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
