### PR TITLE
Fix lexer on "?" and "+="

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,40 @@
-# v 1.6.0 (?)
+# v 1.6.0 (22-06-20)
+
 Changes in this release:
+
+-   Fix issue with "+" assignation and "?" in lexer
 
 # v 1.5.0 (2022-01-24)
+
 Changes in this release:
-- Fix compatibility with recommonmark
-- Fix compatibility with inmanta modules V2
-- Added explicit project install for compatibility with latest inmanta-core
+
+-   Fix compatibility with recommonmark
+-   Fix compatibility with inmanta modules V2
+-   Added explicit project install for compatibility with latest inmanta-core
 
 # v 1.4.0 (2021-04-15)
+
 Changes in this release:
- - Correctly create an instance of the Project class.
- - Use stable inmanta-core api
+
+-   Correctly create an instance of the Project class.
+-   Use stable inmanta-core api
 
 # 1.3.0 (20-06-30)
 
 ## Change
- - Don't perform a full compile on documentation generation (#31)
- - Use * instead of \* to describe a relationship without upper bound.
+
+-   Don't perform a full compile on documentation generation (#31)
+-   Use \* instead of \* to describe a relationship without upper bound.
 
 # 1.2.0 (04-27-2020)
 
 ## Change
- - Handle empty description correctly.
- - Added namespace-files option to show-options directive
+
+-   Handle empty description correctly.
+-   Added namespace-files option to show-options directive
 
 # 1.0.0
 
 ## Change
- - Options are no longer quoted by inmanta-sphinx but by inmanta config framework
+
+-   Options are no longer quoted by inmanta-sphinx but by inmanta config framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.6.0 (?)
 Changes in this release:
 - Fix issue with "+" assignation and "?" in lexer
+
 # v 1.5.0 (2022-01-24)
 Changes in this release:
 - Fix compatibility with recommonmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 1.6.0 (22-06-20)
+# v 1.6.0 (?)
 Changes in this release:
 - Fix issue with "+" assignation and "?" in lexer
 # v 1.5.0 (2022-01-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,30 @@
 # v 1.6.0 (22-06-20)
-
 Changes in this release:
-
--   Fix issue with "+" assignation and "?" in lexer
-
+- Fix issue with "+" assignation and "?" in lexer
 # v 1.5.0 (2022-01-24)
-
 Changes in this release:
-
--   Fix compatibility with recommonmark
--   Fix compatibility with inmanta modules V2
--   Added explicit project install for compatibility with latest inmanta-core
+- Fix compatibility with recommonmark
+- Fix compatibility with inmanta modules V2
+- Added explicit project install for compatibility with latest inmanta-core
 
 # v 1.4.0 (2021-04-15)
-
 Changes in this release:
-
--   Correctly create an instance of the Project class.
--   Use stable inmanta-core api
+ - Correctly create an instance of the Project class.
+ - Use stable inmanta-core api
 
 # 1.3.0 (20-06-30)
 
 ## Change
-
--   Don't perform a full compile on documentation generation (#31)
--   Use \* instead of \* to describe a relationship without upper bound.
+ - Don't perform a full compile on documentation generation (#31)
+ - Use * instead of \* to describe a relationship without upper bound.
 
 # 1.2.0 (04-27-2020)
 
 ## Change
-
--   Handle empty description correctly.
--   Added namespace-files option to show-options directive
+ - Handle empty description correctly.
+ - Added namespace-files option to show-options directive
 
 # 1.0.0
 
 ## Change
-
--   Options are no longer quoted by inmanta-sphinx but by inmanta config framework
+ - Options are no longer quoted by inmanta-sphinx but by inmanta config framework

--- a/sphinxcontrib/inmanta/pygments_lexer.py
+++ b/sphinxcontrib/inmanta/pygments_lexer.py
@@ -71,7 +71,7 @@ class InmantaLexer(RegexLexer):
             ("[\"]{3}([\\n]|.)*?[\"]{3}", Comment.Multiline),  # t_begin_mls
             ("\n+", Whitespace),  # t_ANY_newline
             ('!=|==|>=|<=|<|>', Token.Operator),  # t_CMP_OP
-            ('[:[\]()=,.{}*]', Token.Operator),  # literals
+            ('[:[\]()=,.{}\?*]|(\+=)', Token.Operator),  # literals
             ("\#.*?\n", Comment.Single),  # t_COMMENT
             ("[-]?[0-9]*[.][0-9]+", Number.Float),  # t_FLOAT
             ("[a-zA-Z_][a-zA-Z_0-9-]*", process_id),  # t_ID


### PR DESCRIPTION
# Description

The lexer fails to parse inmanta models where an entity contains an attribute of type string[]? or using the += assignation.
This commit fixes this.

closes #51

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
