### PR TITLE
Ensure clear representation of an empty string default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.6.0 (?)
 Changes in this release:
 - Fix issue with "+" assignation and "?" in lexer
+- Ensure that environment settings with an empty string as a default value are represented as ''
 
 # v 1.5.0 (2022-01-24)
 Changes in this release:

--- a/sphinxcontrib/inmanta/environmentsettings.py
+++ b/sphinxcontrib/inmanta/environmentsettings.py
@@ -106,7 +106,8 @@ def _format_setting_help():
         else:
             yield _indent(f":Type: {setting.typ}: {', '.join(setting.allowed_values)}")
 
-        yield _indent(':Default: %s' % setting.default)
+        default_value = "''" if isinstance(setting.default, str) and not setting.default else setting.default
+        yield _indent(f':Default: {default_value}')
         yield ""
         yield _indent(setting.doc)
 


### PR DESCRIPTION
# Description

Ensure that environment settings with an empty string as a default value are represented as '' in the documentation.

closes inmanta/inmanta-core#4628

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
