### PR TITLE
[FIX] fix lexer not recognizing simple quotes as valid string delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.8.0 (?)
 Changes in this release:
+- Fix lexer bug not recognizing simple quotes as a valid string delimiter.
 
 # v 1.7.0 (2022-12-20)
 Changes in this release:

--- a/sphinxcontrib/inmanta/pygments_lexer.py
+++ b/sphinxcontrib/inmanta/pygments_lexer.py
@@ -80,8 +80,8 @@ class InmantaLexer(RegexLexer):
             ("/[^/]*/", String.Regex),  # t_REGEX
             ("--|->|<-", Token.Operator),  # t_REL
             ("[:]{2}", Name),  # t_SEP
-            (r'\".*?[^\\]\"', String),  # t_STRING
-            ("\"\"", String),  # t_STRING_EMPTY
+            (r'\".*?[^\\]\"|\'.*?[^\\]\'', String),  # t_STRING
+            ("\"\"|\'\'", String),  # t_STRING_EMPTY
             ("[ \t]+", Whitespace)  # t_ignore
 
         ],


### PR DESCRIPTION
# Description

Part of https://github.com/inmanta/inmanta-core/pull/6457


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
