### PR TITLE
Remove rule for matching keyword

### DIFF
--- a/sphinxcontrib/inmanta/pygments_lexer.py
+++ b/sphinxcontrib/inmanta/pygments_lexer.py
@@ -55,7 +55,6 @@ class InmantaLexer(RegexLexer):
     tokens = {
         'root': [
             (r"(matching)([ \t]+)(/(?:[^/\\\n]|\\.)+/)", bygroups(Keyword, Whitespace, String.Regex)),
-            (r"matching", Keyword),
             (r'(entity)([ \t]+)([a-zA-Z_][a-zA-Z_0-9-]*)', bygroups(Keyword, Whitespace, Name.Class), 'entity-extend'),
             # old style relation Host mgr [0:] -- [1] odl::ODL odl
             (in_class_name + whitespace + ident + whitespace + multi_like + whitespace + in_class_name + whitespace + ident,


### PR DESCRIPTION
# Description

Because it would incorrectly highlight identifiers that start with the `matching`.

Part of inmanta/inmanta-core#1799

# Self Check:

- [x] Attached issue to pull request
- [ ] ~~Changelog entry~~
- [z] Code is clear and sufficiently documented
- [z] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
