### PR TITLE
Major bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 2.0.0 (2024-08-05)
+# v 1.2.0 (?)
 Changes in this release:
 - Use the README.md file to control what is included in the documentation. Use `--autodoc-only` to restore the previous behavior.
 - Update command to generate module documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 1.2.0 (?)
+# v 1.12.0 (?)
 Changes in this release:
 - Use the README.md file to control what is included in the documentation. Use `--autodoc-only` to restore the previous behavior.
 - Update command to generate module documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes in this release:
 - Update command to generate module documentation:
     - replaced `--file` argument with `--out-dir` to support multi-file docs
     - renamed `--module_repo` to `--module-sources`
+    - renamed `--module` to `--module-name`
 
 # v 1.11.0 (2024-08-02)
 This release was yanked and rereleased as 2.0.0 due to breaking changes in the interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-# v 1.12.0 (?)
+# v 2.0.0 (2024-08-05)
 Changes in this release:
+- Use the README.md file to control what is included in the documentation. Use `--autodoc-only` to restore the previous behavior.
+- Update command to generate module documentation:
+    - replaced `--file` argument with `--out-dir` to support multi-file docs
+    - renamed `--module_repo` to `--module-sources`
 
 # v 1.11.0 (2024-08-02)
-Changes in this release:
-- Update command to generate module documentation.
-- Use the README.md file to control what is included in the documentation.
+This release was yanked and rereleased as 2.0.0 due to breaking changes in the interface
 
 # v 1.10.0 (2024-06-12)
 Changes in this release:


### PR DESCRIPTION
# Description

Expanded changelog relating to breaking change and prepare for yanking it to make it a major instead. The changelog still contains 1.12.0 because the (old) release tool bumps it to major at release time (and breaks if it doesn't find the expected version).

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
