### PR TITLE
Drop iso6

### DIFF
--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -30,7 +30,7 @@ pipeline {
         axes {
           axis {
             name "CORE_BRANCH"
-            values "master", "iso6", "iso7"
+            values "master", "iso7"
           }
           axis {
             name "MODULES_V2"


### PR DESCRIPTION
# Description

ISO6 has been removed from the jenkinsfile

Part of https://github.com/inmanta/infra-tickets/issues/207

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
