### PR TITLE
Fix doc build failing on ISO8

### DIFF
--- a/sphinxcontrib/inmanta/api.py
+++ b/sphinxcontrib/inmanta/api.py
@@ -265,7 +265,7 @@ pip:
 
         def get_handler(name: str) -> Sequence[type[ResourceHandler]]:
             # ISO8 and pre ISO8 compatiblity
-            handlers = handler.Commander.get_handlers()[name]
+            handlers = handler.Commander.get_handlers().get(name, {})
             # signature was def get_handlers(cls) -> dict[str, dict[str, type[ResourceHandler[Any]]]]:
             if isinstance(handlers, dict):
                 return handlers.values()


### PR DESCRIPTION
# Description

@wouterdb Do you know why we changed from `defaultdict` to a simple `dict`: https://github.com/inmanta/inmanta-core/pull/7976/files#diff-6fe603b0e2ead0d2899810275d0ed57935e40cd1daf59b0424fb3cc0d5c6e53dL1074? I suppose the goal was to expose issues like the one happening for ISO8

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
