### PR TITLE
install dev extra

### DIFF
--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -77,8 +77,7 @@ pipeline {
                 rm -rf $INMANTA_TEST_ENV
                 ${PYTHON_BINARY} -m venv $INMANTA_TEST_ENV
                 $INMANTA_TEST_ENV/bin/python3 -m pip install --upgrade pip setuptools
-                $INMANTA_TEST_ENV/bin/python3 -m pip install -r ./inmanta-core/requirements.txt -r ./inmanta-core/requirements.dev.txt
-                $INMANTA_TEST_ENV/bin/python3 -m pip install ./inmanta-core ./inmanta-sphinx
+                $INMANTA_TEST_ENV/bin/python3 -m pip install ./inmanta-core[dev] ./inmanta-sphinx
                 rm -rf inmanta-core/docs/reference/modules
                 mkdir inmanta-core/docs/reference/modules
               '''


### PR DESCRIPTION
I did not add `-c inmanta-core/requirements.txt` because it pins `inmanta-sphinx`, which breaks the install. While we may be able to find a way around that issue, I don't think it's strictly required either, since this is the inmanta-sphinx test suite, and not the inmanta-core one.