### PR TITLE
Fix jenkinsfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the embedded documentation to generate a config reference.
 It adds the show-options directive and a number of config objects to sphinx. Within the show-options directive, the
  namespaces should be specified that contain the Option() definitions. This can be done in two different ways. Either
  directly in the content of the show-options directive or indirectly via the namespace-files option. Both options don't
- have to be used simultaneously Use it like this to generate documentation:
+ have to be used simultaneously. Use it like this to generate documentation:
 
 ```
 .. show-options::
@@ -40,14 +40,15 @@ entities, relations, ...
 
 ## Inmanta doc gen
 
-To generate inmanta docs for a module, use the following
+To generate inmanta docs for a module, use the following:
 
 ```bash
 python -m sphinxcontrib.inmanta.api --module_repo folder_with_modules --module module_name  --file autodoc.rst
 ```
 
 To control what is added to the module, add the following to the `pyproject.toml` of the module
-The `module_filter` is a list of regexes, only submodules of which the name match one of the regexes are included
+The `module_filter` is a list of regexes, only submodules of which the name match one of the regexes are included:
+
 ```toml
 [tool.inmanta-sphinx.docgen]
 module_filter = ["^module_name"] # Only include main module, no submodules

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -12,7 +12,6 @@ def get_std_v1_module_branch(core_branch) {
 
 def get_compatible_std_version(core_branch) {
     // Retrieve the constraints on the (V2) std module from the compatibility file
-    println "get_compatible_std_version core_branch: " + core_branch
     def iso_version
     def match
     if (core_branch ==~ /master/) {
@@ -27,7 +26,6 @@ def get_compatible_std_version(core_branch) {
             iso_version = "invalid_branch"
         }
     }
-    println "get_compatible_std_version iso_version: " + iso_version
     def sh_script = """
 curl https://docs.inmanta.com/inmanta-service-orchestrator/${iso_version}/reference/compatibility.json | jq -r '.module_compatibility_ranges["inmanta-module-std"]'
 """

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -72,7 +72,7 @@ pipeline {
                 '''
               }
               sh '''
-                export PYTHON_BINARY=$(irt -v DEBUG get-python-version-for-checkout --map-file ${WORKSPACE}/branch-to-python-version.json --path ${WORKSPACE}/inmanta-core)
+                export PYTHON_BINARY=$(irt -v DEBUG get-python-version-for-checkout --map-file ${WORKSPACE}/branch-to-python-version.json --path ${WORKSPACE}/inmanta-core) --branch ${CORE_BRANCH}
                 echo "Tests will be run with ${PYTHON_BINARY}"
                 rm -rf $INMANTA_TEST_ENV
                 ${PYTHON_BINARY} -m venv $INMANTA_TEST_ENV

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -135,9 +135,7 @@ pipeline {
                 # uninstall v2 so it doesn't take precedence over v1 automatically
                 $INMANTA_TEST_ENV/bin/python3 -m pip uninstall inmanta-module-std -y
                 $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
-                cd ${WORKSPACE}/inmanta-core/docs
                 $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
-                cd ${WORKSPACE}
               '''
             }
           }
@@ -158,9 +156,7 @@ pipeline {
                 def sh_script = '''
                     $INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std${Std_Constraints} --pre
                     $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
-                    cd ${WORKSPACE}/inmanta-core/docs
                     $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
-                    cd ${WORKSPACE}
                 '''
                 sh(returnStdout: false, script: sh_script)
               }

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -1,3 +1,37 @@
+def get_v1_module_branch(core_branch) {
+    if (core_branch ==~ /master|iso8/) {
+        return '*/master'
+    }
+    if (core_branch ==~ /iso7/) {
+        return '*/iso7'
+    }
+    return "invalid_branch"
+}
+
+def get_compatible_std_version(core_branch) {
+    println "get_compatible_std_version core_branch: " + core_branch
+    def iso_version
+    def match
+    if (core_branch ==~ /master/) {
+        iso_version = "latest"
+    }
+    else {
+         try {
+            // do not store Matcher object in variable!
+            // see https://www.jenkins.io/doc/book/pipeline/pipeline-best-practices/#avoiding-notserializableexception
+            iso_version = (core_branch =~ /^iso(\d+)$/)[0][1]
+        } catch (IndexOutOfBoundsException) {
+            iso_version = "invalid_branch"
+        }
+    }
+    println "get_compatible_std_version iso_version: " + iso_version
+    def sh_script = """
+curl https://docs.inmanta.com/inmanta-service-orchestrator/${iso_version}/reference/compatibility.json | jq -r '.module_compatibility_ranges["inmanta-module-std"]'
+"""
+    sh(returnStdout: true, script: sh_script)
+}
+
+
 pipeline {
   agent any
   options {
@@ -92,9 +126,17 @@ pipeline {
               dir("std") {
                 deleteDir()
               }
-              checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
+              script {
+                  println "Core branch:" + env.CORE_BRANCH
+                  def v1_module_branch = get_v1_module_branch(env.CORE_BRANCH)
+                  println "v1_module_branch:" + v1_module_branch
+                  checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: v1_module_branch]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
+
+              }
 
               sh '''
+                # uninstall v2 so it doesn't take precedence over v1 automatically
+                $INMANTA_TEST_ENV/bin/python3 -m pip uninstall inmanta-module-std -y
                 $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
                 cd ${WORKSPACE}/inmanta-core/docs
                 $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
@@ -111,14 +153,22 @@ pipeline {
               dir("std") {
                 deleteDir()
               }
-              sh '$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std --pre'
+              script{
+                println "Core branch:" + env.CORE_BRANCH
+                env.Std_Constraints = get_compatible_std_version(env.CORE_BRANCH)
+                println "std_constraints:" + env.Std_Constraints
 
-              sh '''
-                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
-                cd ${WORKSPACE}/inmanta-core/docs
-                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
-                cd ${WORKSPACE}
-              '''
+                def sh_script = '''
+                    $INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std${Std_Constraints} --pre
+                    $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
+                    cd ${WORKSPACE}/inmanta-core/docs
+                    $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
+                    cd ${WORKSPACE}
+                '''
+                sh(returnStdout: false, script: sh_script)
+              }
+
+
             }
           }
         }

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -95,8 +95,10 @@ pipeline {
               checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
 
               sh '''
-                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir inmanta-core/docs/reference/modules/
-                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build
+                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
+                cd ${WORKSPACE}/inmanta-core/docs
+                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
+                cd ${WORKSPACE}
               '''
             }
           }
@@ -112,8 +114,10 @@ pipeline {
               sh '$INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std --pre'
 
               sh '''
-                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir inmanta-core/docs/reference/modules/
-                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html inmanta-core/docs build
+                $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
+                cd ${WORKSPACE}/inmanta-core/docs
+                $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
+                cd ${WORKSPACE}
               '''
             }
           }

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -1,6 +1,6 @@
 def get_std_v1_module_branch(core_branch) {
     // Hard codes which branch of the std module git repo to use when using
-    // it as a V1 module. (V1 modules are no longer used iso9 onwards)
+    // it as a V1 module. (V1 modules are no longer used iso8 onwards)
     if (core_branch ==~ /master|iso8/) {
         return '*/master'
     }
@@ -10,22 +10,21 @@ def get_std_v1_module_branch(core_branch) {
     throw new IllegalArgumentException("invalid_branch")
 }
 
-def get_compatible_std_version(core_branch) {
-    // Retrieve the constraints on the (V2) std module from the compatibility file
+def get_requirements_file_url(core_branch) {
+    // Retrieve the requirements file for the given core branch
     def iso_version
-    def match
+    def dev_version = ""
     if (core_branch ==~ /master/) {
         iso_version = "latest"
+        dev_version = "-dev"
     }
     else {
         // do not store Matcher object in variable!
         // see https://www.jenkins.io/doc/book/pipeline/pipeline-best-practices/#avoiding-notserializableexception
         iso_version = (core_branch =~ /^iso(\d+)$/)[0][1]
     }
-    def sh_script = """
-curl https://docs.inmanta.com/inmanta-service-orchestrator/${iso_version}/reference/compatibility.json | jq -r '.module_compatibility_ranges["inmanta-module-std"]'
-"""
-    sh(returnStdout: true, script: sh_script)
+    return "https://docs.inmanta.com/inmanta-service-orchestrator${dev_version}/${iso_version}/reference/requirements.txt"
+
 }
 
 
@@ -150,11 +149,13 @@ pipeline {
               }
               script{
                 println "Core branch: " + env.CORE_BRANCH
-                env.Std_Constraints = get_compatible_std_version(env.CORE_BRANCH)
-                println "std_constraints: " + env.Std_Constraints
+                env.REQUIREMENTS_FILE = get_requirements_file_url(env.CORE_BRANCH)
+                println "REQUIREMENTS_FILE: " + env.REQUIREMENTS_FILE
 
                 def sh_script = '''
-                    $INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std${Std_Constraints} --pre
+                    # Use the constraints on the (V2) std module from the requirements file for this iso version.
+
+                    $INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std --pre -c ${REQUIREMENTS_FILE}
                     $INMANTA_TEST_ENV/bin/python3 -m sphinxcontrib.inmanta.api --module-sources $(pwd) --module-name std  --out-dir ${WORKSPACE}/inmanta-core/docs/reference/modules/
                     $INMANTA_TEST_ENV/bin/python3 -m sphinx.cmd.build -vv -T -b html ${WORKSPACE}/inmanta-core/docs build
                 '''

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -7,7 +7,7 @@ def get_std_v1_module_branch(core_branch) {
     if (core_branch ==~ /iso7/) {
         return '*/iso7'
     }
-    return "invalid_branch"
+    throw new IllegalArgumentException("invalid_branch")
 }
 
 def get_compatible_std_version(core_branch) {
@@ -18,13 +18,9 @@ def get_compatible_std_version(core_branch) {
         iso_version = "latest"
     }
     else {
-         try {
-            // do not store Matcher object in variable!
-            // see https://www.jenkins.io/doc/book/pipeline/pipeline-best-practices/#avoiding-notserializableexception
-            iso_version = (core_branch =~ /^iso(\d+)$/)[0][1]
-        } catch (IndexOutOfBoundsException) {
-            iso_version = "invalid_branch"
-        }
+        // do not store Matcher object in variable!
+        // see https://www.jenkins.io/doc/book/pipeline/pipeline-best-practices/#avoiding-notserializableexception
+        iso_version = (core_branch =~ /^iso(\d+)$/)[0][1]
     }
     def sh_script = """
 curl https://docs.inmanta.com/inmanta-service-orchestrator/${iso_version}/reference/compatibility.json | jq -r '.module_compatibility_ranges["inmanta-module-std"]'

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -72,7 +72,7 @@ pipeline {
                 '''
               }
               sh '''
-                export PYTHON_BINARY=$(irt -v DEBUG get-python-version-for-checkout --map-file ${WORKSPACE}/branch-to-python-version.json --path ${WORKSPACE}/inmanta-core) --branch ${CORE_BRANCH}
+                export PYTHON_BINARY=$(irt -v DEBUG get-python-version-for-checkout --map-file ${WORKSPACE}/branch-to-python-version.json --path ${WORKSPACE}/inmanta-core)
                 echo "Tests will be run with ${PYTHON_BINARY}"
                 rm -rf $INMANTA_TEST_ENV
                 ${PYTHON_BINARY} -m venv $INMANTA_TEST_ENV

--- a/ci/Jenkinsfile-test
+++ b/ci/Jenkinsfile-test
@@ -1,4 +1,6 @@
-def get_v1_module_branch(core_branch) {
+def get_std_v1_module_branch(core_branch) {
+    // Hard codes which branch of the std module git repo to use when using
+    // it as a V1 module. (V1 modules are no longer used iso9 onwards)
     if (core_branch ==~ /master|iso8/) {
         return '*/master'
     }
@@ -9,6 +11,7 @@ def get_v1_module_branch(core_branch) {
 }
 
 def get_compatible_std_version(core_branch) {
+    // Retrieve the constraints on the (V2) std module from the compatibility file
     println "get_compatible_std_version core_branch: " + core_branch
     def iso_version
     def match
@@ -127,10 +130,10 @@ pipeline {
                 deleteDir()
               }
               script {
-                  println "Core branch:" + env.CORE_BRANCH
-                  def v1_module_branch = get_v1_module_branch(env.CORE_BRANCH)
-                  println "v1_module_branch:" + v1_module_branch
-                  checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: v1_module_branch]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
+                  println "Core branch: " + env.CORE_BRANCH
+                  def std_v1_module_branch = get_std_v1_module_branch(env.CORE_BRANCH)
+                  println "std_v1_module_branch: " + std_v1_module_branch
+                  checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: std_v1_module_branch]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'std']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'inmantaci', url: 'https://github.com/inmanta/std.git']]]
 
               }
 
@@ -154,9 +157,9 @@ pipeline {
                 deleteDir()
               }
               script{
-                println "Core branch:" + env.CORE_BRANCH
+                println "Core branch: " + env.CORE_BRANCH
                 env.Std_Constraints = get_compatible_std_version(env.CORE_BRANCH)
-                println "std_constraints:" + env.Std_Constraints
+                println "std_constraints: " + env.Std_Constraints
 
                 def sh_script = '''
                     $INMANTA_TEST_ENV/bin/python3 -m pip install inmanta-module-std${Std_Constraints} --pre


### PR DESCRIPTION
# Description
The jenkinsfile had a couple of issues:

- it was always using std v2 even in the 'test v1' case ( I believe since we added std to the 'dev' extra of core, and we initialize the venv with this extra)
- it was failing for the iso7 dimension of the matrix because it was incorrectly using std branch master (instead of iso7)
- it was failing for the other cells of the matrix with `FileNotFoundError: [Errno 2] No such file or directory: 'scorer.js'` -> For this one I don't know the cause, but I found a solution: first cd into the `inmanta-core/docs` dir and only then invoke the sphinx build command.

Merging this PR should also fix the following error by updating the last commit hash:
```
Could not update commit status. Message: {"message":"Validation Failed","errors":"Validation failed: This SHA and context has reached the maximum number of statuses.","documentation_url":"https://docs.github.com/rest/commits/statuses#create-a-commit-status","status":"422"}
```
Root cause is that this repo is not very active and the commit status limit of 1000 was reached.



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
